### PR TITLE
Fix typo and link on VelogPostSeries.node

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -57,7 +57,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
         posts: {
           type: '[VelogPost!]!',
           resolve(source: { velogId: string }, _args, context) {
-            return context.nodeModle.runQuery({
+            return context.nodeModel.runQuery({
               type: 'VelogPost',
               query: {
                 filter: {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -212,7 +212,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
           extensions: {
             link: {
               by: 'velogId',
-              from: 'series.velogId',
+              from: 'velogId',
             },
           },
         }


### PR DESCRIPTION
1. `TypeError: Cannot read property 'runQuery' of undefined"` error occurred on `gatsby-node.js:71:36`. cause of it was referring to context.nodeModle.runQuery, so modified it to `nodeModel`.

1. `Error: Cannot return null for non-nullable field VelogPostSeries.node.` error occurred: `@link({from: 'series.velogId'})` change to `@link({from: 'velogId'}) .`