### PR TITLE
Create VelogPost child infer types and create correct internal.mediaType

### DIFF
--- a/src/__generated__/sdk.ts
+++ b/src/__generated__/sdk.ts
@@ -489,7 +489,7 @@ export type GetPostsByUsernameQueryVariables = Exact<{
 }>;
 
 
-export type GetPostsByUsernameQuery = { __typename?: 'Query', posts: Maybe<Array<Maybe<{ __typename?: 'Post', thumbnail: Maybe<string>, title: Maybe<string>, tags: Maybe<Array<Maybe<string>>>, velogId: string, shortDescription: Maybe<string>, slug: Maybe<string>, publishedAt: Maybe<any>, updatedAt: Maybe<any>, rawContent: Maybe<string>, author: Maybe<{ __typename?: 'User', username: Maybe<string>, velogId: string }>, series: Maybe<{ __typename?: 'Series', velogId: string, seriesPosts: Maybe<Array<Maybe<{ __typename?: 'SeriesPost', index: Maybe<number>, item: Maybe<{ __typename?: 'Post', velogId: string }> }>>> }> }>>> };
+export type GetPostsByUsernameQuery = { __typename?: 'Query', posts: Maybe<Array<Maybe<{ __typename?: 'Post', thumbnail: Maybe<string>, title: Maybe<string>, tags: Maybe<Array<Maybe<string>>>, velogId: string, shortDescription: Maybe<string>, slug: Maybe<string>, publishedAt: Maybe<any>, updatedAt: Maybe<any>, rawContent: Maybe<string>, isMarkdown: Maybe<boolean>, author: Maybe<{ __typename?: 'User', username: Maybe<string>, velogId: string }>, series: Maybe<{ __typename?: 'Series', velogId: string, seriesPosts: Maybe<Array<Maybe<{ __typename?: 'SeriesPost', index: Maybe<number>, item: Maybe<{ __typename?: 'Post', velogId: string }> }>>> }> }>>> };
 
 export type GetSeriesListByUsernameQueryVariables = Exact<{
   username: Scalars['String'];
@@ -540,6 +540,7 @@ export const GetPostsByUsernameDocument = gql`
     publishedAt: released_at
     updatedAt: updated_at
     rawContent: body
+    isMarkdown: is_markdown
     author: user {
       velogId: id
       username

--- a/src/documents.graphql
+++ b/src/documents.graphql
@@ -36,6 +36,7 @@ query getPostsByUsername($username: String!, $cursor: ID) {
     publishedAt: released_at
     updatedAt: updated_at
     rawContent: body
+    isMarkdown: is_markdown
     author: user {
       velogId: id
       username

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -403,7 +403,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({
       children: [],
       internal: {
         type: 'VelogPost',
-        mediaType: 'text/markdown',
+        mediaType: post.isMarkdown ? 'text/markdown': undefined,
         content: post.rawContent ?? '',
         contentDigest: createContentDigest(postSource),
       },

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -134,7 +134,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       name: 'VelogPost',
       interfaces: ['Node'],
       extensions: {
-        infer: false,
+        infer: true,
       },
       fields: {
         velogId: 'String!',


### PR DESCRIPTION
- Change the extension `infer` property to `true` to create childMarkdownRemark under VelogPost
- Create the correct VelogPost.internal.mediaType based on the velog Post.is_markdown field